### PR TITLE
Update VisionClassifierTrainer

### DIFF
--- a/hugsvision/nnet/VisionClassifierTrainer.py
+++ b/hugsvision/nnet/VisionClassifierTrainer.py
@@ -34,7 +34,7 @@ class VisionClassifierTrainer:
     cores         = 4,
     batch_size    = 8,
     lr            = 2e-5,
-    eval_metric   = "accuracy",
+    eval_metric   = "loss",
     fp16          = False,
     classification_report_digits = 4,
     checkpoint_path = None,
@@ -62,14 +62,14 @@ class VisionClassifierTrainer:
 
     # Processing device (CPU / GPU)
     self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    
+
     # Get the classifier collator
     self.collator = ImageClassificationCollator(self.feature_extractor)
 
     # Get the model output path
     self.output_path = self.__getOutputPath()
     self.logs_path   = self.output_path
-    
+
     # Open the logs file
     self.__openLogs()
 
@@ -87,12 +87,12 @@ class VisionClassifierTrainer:
         num_train_epochs            = self.max_epochs,
         metric_for_best_model       = self.eval_metric,
         logging_dir                 = self.logs_path,
-        evaluation_strategy         = "epoch",
+        eval_strategy               = "epoch",
         load_best_model_at_end      = False,
         overwrite_output_dir        = True,
         fp16=self.fp16,
     )
-    
+
     self.trainer = Trainer(
       self.model,
       self.training_args,
@@ -122,7 +122,7 @@ class VisionClassifierTrainer:
   """
   📜 Open the logs file
   """
-  def __openLogs(self):    
+  def __openLogs(self):
 
     # Open the logs file
     self.logs_file = open(self.logs_path + "/logs.txt", "a")
@@ -174,7 +174,7 @@ class VisionClassifierTrainer:
   🧪 Evaluate the performances of the system of the test sub-dataset
   """
   def evaluate(self):
-        
+
     all_preds  = []
     all_target = []
 


### PR DESCRIPTION
Hello Yanis.

Recently I am taking a Pytorch course in Coursera "Advanced PyTorch Techniques and Applications" and the lecturer used your library for teaching in Module 5 of the course.

When I wrote the code following him I found a fatal problem from your library since it is now currently a beta version. 

The problem came from VisionClassifierTrainer. 
In the lastest version of library transfomers from huggingface, the class TrainingArguments now changes the keyword "evaluation_strategy" to “eval_strategy” thus your original code didn't work. 

I have to change the keyword following the instruction of https://github.com/huggingface/transformers/issues/7974#issuecomment-2803578764.

After the change, my training can run but another error came out.

**KeyError: "The `metric_for_best_model` training argument is set to 'eval_accuracy', which is not found in the evaluation metrics. The available evaluation metrics are: ['eval_loss']. Consider changing the `metric_for_best_model` via the TrainingArguments."**

I have to go back to read the code from transformers and found they now only support "loss" as the endword. Thus I changed "accuracy" to "loss" for eval_metrc.

Finally, I can run the training from the course.

Thank you very much for you to work on this easy-to-use library for us to learn Pytorch and deep learning. 
I hope my PR could help you to update and maintain it.